### PR TITLE
Resolves #2 fix repeated firing of addListener

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,16 +3,18 @@ try {
     console.log(`[Jisho-Anki] Background running!`);
 
     chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-        chrome.tabs.get(tabId, (current) => {
-            if (current.url.includes('jisho.org') && changeInfo.status === 'complete') {
-                chrome.tabs.executeScript(null, { // Should this use tabId instead?
-                    file: './src/foreground.js'
-                }, () => {
-                    console.log('Injected foreground script.');
-                    // What if we put our onConnect#addListener event here?
-                });
-            }
-        });
+        if (info.status == "complete") {
+            chrome.tabs.get(tabId, (current) => {
+                if (current.url.includes('jisho.org') && changeInfo.status === 'complete') {
+                    chrome.tabs.executeScript(null, { // Should this use tabId instead?
+                        file: './src/foreground.js'
+                    }, () => {
+                        console.log('Injected foreground script.');
+                        // What if we put our onConnect#addListener event here?
+                    });
+                }
+            });
+        }
     });
 
     chrome.extension.onConnect.addListener((port) => {


### PR DESCRIPTION
The issue was related to addListener firing everytime the tab status changes. This happens multiple times before the tab is done loading. My fix is to only fire addListener when the page status is 'complete'.