### PR TITLE
Resolve #2 Fix foreground.js executing twice

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -2,19 +2,6 @@ try {
     const ANKI_CONNECT_URL = 'http://localhost:8765'
     console.log(`[Jisho-Anki] Background running!`);
 
-    chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-        chrome.tabs.get(tabId, (current) => {
-            if (current.url.includes('jisho.org') && changeInfo.status === 'complete') {
-                chrome.tabs.executeScript(null, { // Should this use tabId instead?
-                    file: './src/foreground.js'
-                }, () => {
-                    console.log('Injected foreground script.');
-                    // What if we put our onConnect#addListener event here?
-                });
-            }
-        });
-    });
-
     chrome.extension.onConnect.addListener((port) => {
         console.log(`Connected to port: ${port.name}`);
         if (port.name === 'jisho-client') {


### PR DESCRIPTION
The cause of this bug is that the foreground.js code is being run exactly two times on each page load
  1. declared statically in manifest.json
  2. injected dynamically through the `chrome.tabs.onUpdated.addListener()` function
  * more info about this in the [Chrome Extension docs][1]

Variables in foreground.js are thus initialized twice, and the resulting namespace collisions of let/const variables causes this issue.

So there are two possible solutions:

1. only declare using manifest.json (recommended - that's what this PR does)
   * method: delete lines 5-16 of background.js
   * upside: this makes the script load earlier, so there is no perceived delay
   * downside: removes the logic that checks for page load completion, could potentially cause issues if foreground.js runs too early? (but I have not been able to find any issues)
2. only inject dynamically
   * method: delete line 11 of manifest.json as well as the ending ',' on the previous line
   * upside: would avoid potential issues related to running foreground.js earlier
   * downside: there is a visible delay (fraction of a second) until the 'Export to Anki' buttons appear on the page

I have not been able to find any issues while testing solution 1, so this is what I would propose. However I can also see the advantage of being careful and going with solution 2.

[1]: https://developer.chrome.com/docs/extensions/mv3/content_scripts/